### PR TITLE
Fix for "invalid option name "16BIT_PIXEL"

### DIFF
--- a/lib/puppet/util/ptomulik/package/ports/options.rb
+++ b/lib/puppet/util/ptomulik/package/ports/options.rb
@@ -51,7 +51,7 @@ module Puppet::Util::PTomulik::Package::Ports
     # @return [Boolean] `true` if `x` is a valid option name, `false` if not.
     def self.option_name?(x)
       x = x.to_s if x.is_a?(Symbol)
-      x.is_a?(String) and x =~ /^[a-zA-Z_]\w*$/
+      x.is_a?(String) and x =~ /^[0-9a-zA-Z_]\w*$/
     end
 
     # Is x valid as option value?


### PR DESCRIPTION
Port "graphics/ImageMagick" has option 16BIT_PIXEL
So if IM installed portsng doesn't work
